### PR TITLE
added important to font-style rules

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -18,8 +18,10 @@
 	font-family: $_o-ft-icons-font-name;
 	display: inline-block;
 	vertical-align: middle;
-	font-weight: normal;
-	font-style: normal;
+	// These are marked as !important as the icon font is not designed to be used with faux bold or faux italic styles
+	// If bolder versions of an icon are required a new SVG should be designed and added to the icon font
+	font-weight: normal !important; 
+	font-style: normal !important;
 	speak: none;
 	text-decoration: inherit;
 	text-transform: none;


### PR DESCRIPTION
I think the need to prevent faux-font variants being applied to icons is so strong that it merits a couple of `!important` rules
