### PR TITLE
Fix output in LibSass

### DIFF
--- a/demos/main.html
+++ b/demos/main.html
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-<!--[if IE 7]>         <html class="o-useragent-ie7 o-hoverable-on"> <![endif]-->
-<!--[if IE 8]>         <html class="o-useragent-ie8 o-hoverable-on"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="o-hoverable-on"> <!--<![endif]-->
+<html class="">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -12,7 +10,7 @@
 	<script>(function(d) { d.className = d.className + ' demo-js'; })(document.documentElement);</script>
 	<link rel="stylesheet" href="/bundles/css?modules=o-ft-icons:/demos/src/demo.scss" />
 </head>
-<body class="">
+<body>
 <ul class="demo-examples">
 	<li class="demo-example">
 		<i class="o-ft-icons-icon o-ft-icons-icon--arrow-down demo-icon"></i>

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -60,16 +60,19 @@
 @mixin _oFtIconsStandardsIcon($icon-class, $character-code, $placement: 'before') {
 	$icon-selectors: oFtIconsGetSelectors("#{$icon-class}:#{$placement}");
 	#{$icon-selectors} {
-		// a hack to enable outputting of a single backslash;
-		// escaping in Sass is a bit of a mess!
+		// Escaping in Sass is a bit of a mess…
 		// https://github.com/sass/sass/issues/659
-		// http://sassmeister.com/gist/04f5be11c5a6b26b8ff9
 		@if function-exists(random) {
 			@if function-exists(selector-nest) {
 				// Sass 3.4
 				content: #{'\"\\' + $character-code + "\""};
 			} @else {
 				// LibSass
+				// Escaping:
+				// https://github.com/sass/libsass/issues/1271
+				//
+				// Outputs a unicode entity instead of a code such as "\f102":
+				// https://github.com/sass/libsass/issues/1231
 				content: "#{'\"\\' + $character-code + "\""}";
 			}
 		} @else {

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -64,9 +64,14 @@
 		// escaping in Sass is a bit of a mess!
 		// https://github.com/sass/sass/issues/659
 		// http://sassmeister.com/gist/04f5be11c5a6b26b8ff9
-		@if function-exists(selector-append) {
-			// Sass 3.4
-			content: unquote("\"\\#{$character-code}\"");
+		@if function-exists(random) {
+			@if function-exists(selector-nest) {
+				// Sass 3.4
+				content: #{'\"\\' + $character-code + "\""};
+			} @else {
+				// LibSass
+				content: "#{'\"\\' + $character-code + "\""}";
+			}
 		} @else {
 			// Sass 3.3
 			content: str-slice("\x", 1, 1) + $character-code;


### PR DESCRIPTION
Note that LibSass actually outputs the character itself instead of the character code.

```scss
icon {
  /* Expected: "\f102" */
  content: "";
}
```

We should remove this workaround when these issues are fixed: https://github.com/sass/libsass/issues/1271 https://github.com/sass/libsass/issues/1231