### PR TITLE
Tidy up oFtIconsGetSvg mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Icon font with helper classes, and resolution-independent SVG icons to load via 
 There are multiple ways to use the icons:
 
 1. Using the CSS helper classes
-2. Extending the predefined Sass placeholders into your own CSS classes
-3. Resolution independent SVGs, using the [responsive image service](http://image.webservices.ft.com/)
+1. Extending the predefined Sass placeholders into your own CSS classes
+1. Resolution independent SVGs, using the [responsive image service](http://image.webservices.ft.com/)
 
 ### 1. Using the CSS helper classes
 
@@ -73,11 +73,13 @@ element {
 	background-image: url('//image.webservices.ft.com/v1/images/raw/fticon:tick?width=100&format=png&source=my-product');
 
 	// Modern browsers: SVG covering the whole size of the element
-	// we declare mutliple backgrounds so that only modern browsers read this property
+	// we declare multiple backgrounds so that only modern browsers read this property
 	background-image: url('//image.webservices.ft.com/v1/images/raw/fticon:tick?format=svg&source=my-product'), none;
 	background-size: cover;
 }
 ```
+
+We provide a mixin to make this easier which is documented in Sassdoc [http://registry.origami.ft.com/components/o-ft-icons#docs-css](http://registry.origami.ft.com/components/o-ft-icons#docs-css).
 
 ----
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -15,10 +15,17 @@
 	@return $aggregated-selector;
 }
 
-/// Sets SVG background retrieved from the image service
-@mixin oFtIconsGetSvg($icon-name, $color: null, $size: 20, $icon-only: false, $use-local-assets: true) {
-	$service-url: "https://image.webservices.ft.com/v1/images/raw/fticon:";
-	$icon-url: "#{$icon-name}";
+/// Get an SVG icon with PNG fallback for ie6-8
+///
+/// @param {String} $icon-name - this should be a reference to an icon included in o-ft-icons eg arrow-down
+/// @param {String} $color - this should be a hex colour value. Used to color the icon. We suggest using an o-colors an o-colors function.
+/// @param {String} $container-width - this is the width to set the icon containing element to. Defaults to 20px. This value is also used to request a PNG fallback of the right size from the image service.
+/// @param {String} $container-height - this is the height to set the icon containing element to.
+/// @param {Bool} $apply-base-styles - defaults to true. If true, will output style rules for the container. If false will only output the background-image property
+/// @param {Bool} $use-local-assets - defaults to true, if true will look for the SVGs to use locally rather than via the image service. Doesn't apply to the fallback which will always be requested from the image service.
+
+@mixin oFtIconsGetSvg($icon-name, $color: null, $container-width: 20, $container-height: 20,  $apply-base-styles: true, $use-local-assets: true) {
+	$service-url: "https://image.webservices.ft.com/v1/images/raw/fticon:#{$icon-name}";
 	$query: "?source=ofticons";
 
 	@if $color != null {
@@ -27,20 +34,24 @@
 	}
 
 	@if ($use-local-assets == true and $color == null) {
-		background-image: url(oAssetsResolve("svg/#{$icon-name}.svg", o-ft-icons)); 
+		background-image: url(oAssetsResolve("svg/#{$icon-name}.svg", o-ft-icons));
 	} @else {
-		background-image: url($service-url + $icon-url + $query + "&format=svg");
+		background-image: url($service-url + $query + "&format=svg");
 	}
 
-	// ie7/8 fallback
-	// It still needs to use the build service
-	background-image: url($service-url + $icon-url + $query + "&format=png&width=#{$size}")\9;
+	// ie7/8 fallback. Uses the `\9` selector hack to target ie6-8.
+	// Hack is documented here: http://browserhacks.com/#hack-ab1bcc7b3a6544c99260f7608f8e845e
+	// It still needs to use the build service  <-- what does this comment mean?
+	background-image: url($service-url + $query + "&format=png&width=#{$container-width}")\9;
 
-	@if ($icon-only == false) {
+	@if ($apply-base-styles == true) {
 		display: inline-block;
-		width: $size + 0px;
-		height: $size + 0px;
+		width: $container-width + 0px;
+		height: $container-height + 0px;
 		background-repeat: no-repeat;
+
+		// Doesn't work in ie8/7/6 in these cases the icon will fill the available space,
+		// which is fine if the containing box is the same shape as the icon (which they mostly will be)
 		background-size: contain;
 		background-position: 50%;
 		background-color: transparent;

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -24,7 +24,7 @@
 /// @param {Bool} $apply-base-styles - defaults to true. If true, will output style rules for the container. If false will only output the background-image property
 /// @param {Bool} $use-local-assets - defaults to true, if true will look for the SVGs to use locally rather than via the image service. Doesn't apply to the fallback which will always be requested from the image service.
 
-@mixin oFtIconsGetSvg($icon-name, $color: null, $container-width: 20, $container-height: 20,  $apply-base-styles: true, $use-local-assets: true) {
+@mixin oFtIconsGetSvg($icon-name, $color: null, $container-width: 20, $container-height: 20, $apply-base-styles: true, $use-local-assets: true) {
 	$service-url: "https://image.webservices.ft.com/v1/images/raw/fticon:#{$icon-name}";
 	$query: "?source=ofticons";
 


### PR DESCRIPTION
This commit

- Updates the README
- Adds Sassdoc
- Renames $icon-only to $apply-base-styles which is easier to understand
- Adds a documentation link for the ie6-8 browser hack
- Renames $size to $container-width
- Adds $container-height
- Removes internal $icon-url and fudges it into $service-url as they are never used independently

This mixin will now set the height and width properties to whatever you pass in
for $container-height and $container-width.

The $container-width property is also used in ie6-8 as a parameter to the
build service to get an icon at the correct width.

There is a gotcha in this implementation which is that it uses
background-position which is not supported in ie6-8, meaning that the icon
container should be in the same aspect ratio as the icon. For most icons this
will be a square.