### PR TITLE
Change support email link to GitHub Issues

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -2,7 +2,7 @@
     "description": "Financial Times icons",
     "origamiType": "module",
     "origamiVersion": 1,
-    "support": "dan.skinner@ft.com",
+    "support": "https://github.com/Financial-Times/o-ft-icons/issues",
     "supportStatus": "active",
     "browserFeatures": {
         "required": [


### PR DESCRIPTION
Changed from an inactive email address to a link that will point towards GitHub Issues for the o-ft-icons repository.